### PR TITLE
Call compareTo() on enum values directly

### DIFF
--- a/src/app/RowersComparator.java
+++ b/src/app/RowersComparator.java
@@ -8,7 +8,7 @@ import java.util.Comparator;
 public class RowersComparator implements Comparator<Rower> {
 
     public int compare(Rower a, Rower b){
-        int i = a.getPosition().toString().compareTo(b.getPosition().toString());
+        int i = a.getPosition().compareTo(b.getPosition());
         if (i != 0){
             return i;
         }


### PR DESCRIPTION
Since enums have compareTo() method, which uses natural ordering (order of declaration enum constants), there is no need to call toString() method to compare them